### PR TITLE
Support recursive structs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Didier "Ptitjes" <ptitjes@free.fr>
 Michael 'Mickey' Lauer <mlauer@vanille-media.de>
 Frederik 'playya' Sdun <Frederik.Sdun@googlemail.com>
+Dominik Fischer <d.f.fischer@web.de>

--- a/src/vala-dbus-binding-tool.vala
+++ b/src/vala-dbus-binding-tool.vala
@@ -510,11 +510,14 @@ public class BindingGenerator : Object {
 		update_indent(-1);
 		output.printf("%s}\n", get_indent());
 
-		if (structs_to_generate.size != 0) {
-			foreach (var entry in structs_to_generate.entries) {
+		while (structs_to_generate.size != 0) {
+			Gee.Map<string, string> structs_to_generate_now
+				= new Gee.HashMap<string, string>(str_hash, str_equal, str_equal);
+			structs_to_generate_now.set_all(structs_to_generate);
+			foreach (var entry in structs_to_generate_now.entries) {
 				generate_struct(entry.key, entry.value, namespace_name);
 			}
-			structs_to_generate.clear();
+			structs_to_generate.unset_all(structs_to_generate_now);
 		}
 	}
 


### PR DESCRIPTION
Nested structs, for example `(b(oss))`, made the program crash because a collection may not be modified while it is still in the process of being iterated. This can be fixed by iterating a copy instead.
