### PR TITLE
support "read" as an access modifier

### DIFF
--- a/src/vala-dbus-binding-tool.vala
+++ b/src/vala-dbus-binding-tool.vala
@@ -919,7 +919,7 @@ public class BindingGenerator : Object {
 		INFO(@"   Generating property $name (originally $realname) of type $typename for $interface_name");
 
 		string owned_specifier = is_simple_type(rawtype) ? "" : "owned";
-		string accessimpl = (accesstype == "readonly") ? @"$owned_specifier get;" : @"$owned_specifier get; set;";
+		string accessimpl = (accesstype == "readonly" || accesstype == "read") ? @"$owned_specifier get;" : @"$owned_specifier get; set;";
 
 		output.printf("\n");
 		output.printf("%s[DBus (name = \"%s\")]\n", get_indent(), realname);


### PR DESCRIPTION
Some descriptions, for example [MPRIS2](http://specifications.freedesktop.org/mpris-spec/latest/), use just `read` to mean `readonly`. This could be treated just as `read` is instead of issuing an error.
