### PR TITLE
Use fixed width integer types for n, i, q, u

### DIFF
--- a/src/vala-dbus-binding-tool.vala
+++ b/src/vala-dbus-binding-tool.vala
@@ -982,10 +982,14 @@ public class BindingGenerator : Object {
 			return "uint8"; // uchar only works since post-vala 0.8.0 (see c4cf64b6590e5cce21febf98b1f3ff935d921fd5)
 		} else if (type.has_prefix("b")) {
 			return "bool";
-		} else if (type.has_prefix("n") || type.has_prefix("i")) {
-			return "int";
-		} else if (type.has_prefix("q") || type.has_prefix("u")) {
-			return "uint";
+		} else if (type.has_prefix("n")) {
+			return "int16";
+		} else if (type.has_prefix("i")) {
+			return "int32";
+		} else if (type.has_prefix("q")) {
+			return "uint16";
+		} else if (type.has_prefix("u")) {
+			return "uint32";
 		} else if (type.has_prefix("x")) {
 			return "int64";
 		} else if (type.has_prefix("t")) {


### PR DESCRIPTION
The DBus specification [1] uses fixed width integer types.

Without using the correct values for at least the 16 bit width
types the following error occurs:

GLib-CRITICAL **: g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed
GLib-CRITICAL **: g_variant_get_uint32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_UINT32)' failed

1: https://dbus.freedesktop.org/doc/dbus-specification.html

I attached a simple demo:

[error-case.tar.gz](https://github.com/freesmartphone/vala-dbus-binding-tool/files/1502311/error-case.tar.gz)
